### PR TITLE
Add Fees + Notional Values Adapters ~ KPIs ~ #1 #2

### DIFF
--- a/fees/valorem/constants.ts
+++ b/fees/valorem/constants.ts
@@ -1,8 +1,9 @@
 import { ChainEndpoints } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
+// TODO: update with mainnet subgraph urls
 export const endpoints: ChainEndpoints = {
-  /** GOERLI */ [CHAIN.ETHEREUM]:
+  [CHAIN.ETHEREUM]:
     "https://api.thegraph.com/subgraphs/name/nickadamson/test-goerli2",
   [CHAIN.ARBITRUM]:
     "https://api.thegraph.com/subgraphs/name/nickadamson/test-goerli2",
@@ -22,7 +23,8 @@ export const methodology = {
     "Premium Volume is calculated with the market price an Option/Claim position is trading for on the Exchange.",
 };
 
+// TODO: update with mainnet deploy timestamps
 export const OSE_DEPLOY_TIMESTAMP_BY_CHAIN = {
-  /** GOERLI */ [CHAIN.ETHEREUM]: 1672722780,
+  [CHAIN.ETHEREUM]: 1672722780,
   [CHAIN.ARBITRUM]: 1672722780,
 };

--- a/fees/valorem/constants.ts
+++ b/fees/valorem/constants.ts
@@ -1,7 +1,6 @@
 import { ChainEndpoints } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 
-// TODO: update with mainnet subgraph urls
 export const endpoints: ChainEndpoints = {
   [CHAIN.ARBITRUM]:
     "https://api.thegraph.com/subgraphs/name/valorem-labs-inc/valorem-v1-arbitrum",

--- a/fees/valorem/constants.ts
+++ b/fees/valorem/constants.ts
@@ -21,5 +21,5 @@ export const methodology = {
 };
 
 export const OSE_DEPLOY_TIMESTAMP_BY_CHAIN = {
-  [CHAIN.ARBITRUM]: 1693583626,
+  [CHAIN.ARBITRUM]: 1693526399,
 };

--- a/fees/valorem/constants.ts
+++ b/fees/valorem/constants.ts
@@ -3,10 +3,8 @@ import { CHAIN } from "../../helpers/chains";
 
 // TODO: update with mainnet subgraph urls
 export const endpoints: ChainEndpoints = {
-  [CHAIN.ETHEREUM]:
-    "https://api.thegraph.com/subgraphs/name/nickadamson/test-goerli2",
   [CHAIN.ARBITRUM]:
-    "https://api.thegraph.com/subgraphs/name/nickadamson/test-goerli2",
+    "https://api.thegraph.com/subgraphs/name/valorem-labs-inc/valorem-v1-arbitrum",
 };
 
 export const methodology = {
@@ -23,8 +21,6 @@ export const methodology = {
     "Premium Volume is calculated with the market price an Option/Claim position is trading for on the Exchange.",
 };
 
-// TODO: update with mainnet deploy timestamps
 export const OSE_DEPLOY_TIMESTAMP_BY_CHAIN = {
-  [CHAIN.ETHEREUM]: 1672722780,
-  [CHAIN.ARBITRUM]: 1672722780,
+  [CHAIN.ARBITRUM]: 1693583626,
 };

--- a/fees/valorem/constants.ts
+++ b/fees/valorem/constants.ts
@@ -1,0 +1,28 @@
+import { ChainEndpoints } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+export const endpoints: ChainEndpoints = {
+  /** GOERLI */ [CHAIN.ETHEREUM]:
+    "https://api.thegraph.com/subgraphs/name/nickadamson/test-goerli2",
+  [CHAIN.ARBITRUM]:
+    "https://api.thegraph.com/subgraphs/name/nickadamson/test-goerli2",
+};
+
+export const methodology = {
+  Fees: "All fees come from users of Valorem Protocol.",
+  UserFees: "Valorem collects fees when users write and exercise options.",
+  Revenue: "All revenue generated comes from user fees.",
+  ProtocolRevenue:
+    "Valorem collects fees when users write and exercise options.",
+  HoldersRevenue: "Valorem has no governance token.",
+  SupplySideRevenue: "Valorem has no LPs.",
+  NotionalVolume:
+    "Notional Volume is calculated with the market value of the Underlying + Exercise assets of a position at the time of Write/Exercise/Redeem/Transfer.",
+  PremiumVolume:
+    "Premium Volume is calculated with the market price an Option/Claim position is trading for on the Exchange.",
+};
+
+export const OSE_DEPLOY_TIMESTAMP_BY_CHAIN = {
+  /** GOERLI */ [CHAIN.ETHEREUM]: 1672722780,
+  [CHAIN.ARBITRUM]: 1672722780,
+};

--- a/fees/valorem/helpers.ts
+++ b/fees/valorem/helpers.ts
@@ -1,0 +1,49 @@
+import request, { gql } from "graphql-request";
+import { Chain } from "@defillama/sdk/build/general";
+import type { ChainEndpoints } from "../../adapters/types";
+import { IValoremDailyRecordsResponse, IValoremDayData } from "./interfaces";
+
+export const dayDataQuery = gql`
+  query ($skipNum: Int) {
+    dayDatas(first: 1000, skip: $skipNum, orderBy: date, orderDirection: asc) {
+      date
+      notionalVolWrittenUSD
+      notionalVolExercisedUSD
+      notionalVolRedeemedUSD
+      notionalVolTransferredUSD
+      notionalVolSettledUSD
+      notionalVolSumUSD
+      notionalVolFeesAccruedUSD
+      notionalVolFeesSweptUSD
+    }
+  }
+`;
+
+export const getAllDailyRecords = async (
+  graphUrls: ChainEndpoints,
+  chain: Chain
+): Promise<IValoremDayData[]> => {
+  const allDailyRecords: IValoremDayData[] = [];
+
+  let moreRemaining = true;
+  let i = 0;
+  while (moreRemaining) {
+    const { dayDatas }: IValoremDailyRecordsResponse = await request(
+      graphUrls[chain],
+      dayDataQuery,
+      {
+        skipNum: i * 1000,
+      }
+    );
+
+    allDailyRecords.push(...dayDatas);
+
+    if (dayDatas.length < 1000) {
+      moreRemaining = false;
+    }
+
+    i++;
+  }
+
+  return allDailyRecords;
+};

--- a/fees/valorem/helpers.ts
+++ b/fees/valorem/helpers.ts
@@ -1,7 +1,13 @@
 import request, { gql } from "graphql-request";
 import { Chain } from "@defillama/sdk/build/general";
 import type { ChainEndpoints } from "../../adapters/types";
-import { IValoremDailyRecordsResponse, IValoremDayData } from "./interfaces";
+import {
+  IValoremDailyRecordsResponse,
+  IValoremDailyTokenRecordsResponse,
+  IValoremDayData,
+  IValoremTokenDayData,
+} from "./interfaces";
+import BigNumber from "bignumber.js";
 
 export const dayDataQuery = gql`
   query ($skipNum: Int, $timestamp: Int) {
@@ -55,4 +61,115 @@ export const getAllDailyRecords = async (
   }
 
   return allDailyRecords;
+};
+
+export const tokensQuery = gql`
+  query {
+    tokens(first: 1000) {
+      id
+      name
+      decimals
+    }
+  }
+`;
+
+export const tokenDayDataQuery = gql`
+  query ($tokenId: String, $skipNum: Int, $timestamp: Int) {
+    tokenDayDatas(
+      first: 1000
+      skip: $skipNum
+      orderBy: date
+      orderDirection: asc
+      where: { date_lte: $timestamp, token_: { id: $tokenId } }
+    ) {
+      date
+      token {
+        symbol
+      }
+      notionalVolWritten
+      notionalVolTransferred
+      notionalVolSettled
+      notionalVolRedeemed
+      notionalVolExercised
+      notionalVolCoreSum
+      volFeesAccrued
+      volFeesSwept
+    }
+  }
+`;
+
+export type DailyTokenRecords = { [key: string]: IValoremTokenDayData[] };
+
+export const getAllDailyTokenRecords = async (
+  graphUrls: ChainEndpoints,
+  chain: Chain,
+  timestamp: number
+): Promise<DailyTokenRecords> => {
+  const {
+    tokens,
+  }: { tokens: { name: string; id: string; decimals: number }[] } =
+    await request(graphUrls[chain], tokensQuery);
+
+  let allDailyTokenRecords: DailyTokenRecords = {};
+
+  const promises = tokens.map(async (token) => {
+    let tokenName = token.name;
+    while (tokenName.includes(" ") || tokenName.includes(" (Arb1)")) {
+      tokenName = tokenName.replace(" (Arb1)", "").replace(" ", "-");
+    }
+    const key = `${tokenName.toLowerCase()}:${token.id}`;
+
+    allDailyTokenRecords[key] = [];
+
+    let moreRemaining = true;
+    let i = 0;
+
+    // should really never have to loop more than once, at least for a few more years
+    while (moreRemaining) {
+      const { tokenDayDatas }: IValoremDailyTokenRecordsResponse =
+        await request(graphUrls[chain], tokenDayDataQuery, {
+          tokenId: token.id,
+          skipNum: i * 1000,
+          timestamp: timestamp,
+        });
+
+      const parsed = tokenDayDatas.map((tokenDayData) => {
+        let parsedValue = Object.keys(tokenDayData).reduce(
+          (acc, key) => {
+            if (key === "token" || key === "date") {
+              return acc;
+            }
+            try {
+              const asBigInt = new BigNumber(
+                tokenDayData[
+                  key as keyof Omit<IValoremTokenDayData, "date" | "token">
+                ]
+              ).times(new BigNumber(10 ** -token.decimals));
+
+              acc[key] = asBigInt.toString();
+            } catch (error) {}
+            return acc;
+          },
+          {
+            date: tokenDayData.date,
+            token: { symbol: tokenDayData.token.symbol },
+          } as Record<any, any>
+        );
+
+        return parsedValue as unknown as IValoremTokenDayData;
+      });
+
+      allDailyTokenRecords[key] = parsed;
+
+      if (tokenDayDatas.length < 1000) {
+        moreRemaining = false;
+      }
+
+      i++;
+    }
+  });
+
+  await Promise.all(promises);
+
+  return allDailyTokenRecords;
 };

--- a/fees/valorem/helpers.ts
+++ b/fees/valorem/helpers.ts
@@ -4,8 +4,14 @@ import type { ChainEndpoints } from "../../adapters/types";
 import { IValoremDailyRecordsResponse, IValoremDayData } from "./interfaces";
 
 export const dayDataQuery = gql`
-  query ($skipNum: Int) {
-    dayDatas(first: 1000, skip: $skipNum, orderBy: date, orderDirection: asc) {
+  query ($skipNum: Int, $timestamp: Int) {
+    dayDatas(
+      first: 1000
+      skip: $skipNum
+      orderBy: date
+      orderDirection: asc
+      where: { date_lte: $timestamp }
+    ) {
       date
       notionalVolWrittenUSD
       notionalVolExercisedUSD
@@ -21,18 +27,21 @@ export const dayDataQuery = gql`
 
 export const getAllDailyRecords = async (
   graphUrls: ChainEndpoints,
-  chain: Chain
+  chain: Chain,
+  timestamp: number
 ): Promise<IValoremDayData[]> => {
   const allDailyRecords: IValoremDayData[] = [];
 
   let moreRemaining = true;
   let i = 0;
+  // should really never have to loop more than once, at least for a few more years
   while (moreRemaining) {
     const { dayDatas }: IValoremDailyRecordsResponse = await request(
       graphUrls[chain],
       dayDataQuery,
       {
         skipNum: i * 1000,
+        timestamp: timestamp,
       }
     );
 

--- a/fees/valorem/helpers.ts
+++ b/fees/valorem/helpers.ts
@@ -12,9 +12,9 @@ export const dayDataQuery = gql`
       notionalVolRedeemedUSD
       notionalVolTransferredUSD
       notionalVolSettledUSD
-      notionalVolSumUSD
-      notionalVolFeesAccruedUSD
-      notionalVolFeesSweptUSD
+      notionalVolCoreSumUSD
+      volFeesAccruedUSD
+      volFeesSweptUSD
     }
   }
 `;

--- a/fees/valorem/index.ts
+++ b/fees/valorem/index.ts
@@ -62,10 +62,10 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
         }
 
         return {
-          dailyFees: todayStats.notionalVolFeesAccruedUSD,
-          dailyUserFees: todayStats.notionalVolFeesAccruedUSD,
-          dailyRevenue: todayStats.notionalVolFeesAccruedUSD,
-          dailyProtocolRevenue: todayStats.notionalVolFeesAccruedUSD,
+          dailyFees: todayStats.volFeesAccruedUSD,
+          dailyUserFees: todayStats.volFeesAccruedUSD,
+          dailyRevenue: todayStats.volFeesAccruedUSD,
+          dailyProtocolRevenue: todayStats.volFeesAccruedUSD,
         };
       };
 
@@ -75,15 +75,12 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
       const totalStatsUpToToday = filteredRecords.reduce(
         (acc, dayData) => {
           return {
-            totalFees:
-              acc.totalFees + Number(dayData.notionalVolFeesAccruedUSD),
+            totalFees: acc.totalFees + Number(dayData.volFeesAccruedUSD),
             totalUserFees:
-              acc.totalUserFees + Number(dayData.notionalVolFeesAccruedUSD),
-            totalRevenue:
-              acc.totalRevenue + Number(dayData.notionalVolFeesAccruedUSD),
+              acc.totalUserFees + Number(dayData.volFeesAccruedUSD),
+            totalRevenue: acc.totalRevenue + Number(dayData.volFeesAccruedUSD),
             totalProtocolRevenue:
-              acc.totalProtocolRevenue +
-              Number(dayData.notionalVolFeesAccruedUSD),
+              acc.totalProtocolRevenue + Number(dayData.volFeesAccruedUSD),
           };
         },
         {

--- a/fees/valorem/index.ts
+++ b/fees/valorem/index.ts
@@ -37,7 +37,11 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
       );
 
       // get all daily records and filter out any that are after the timestamp
-      const allDailyRecords = await getAllDailyRecords(graphUrls, chain);
+      const allDailyRecords = await getAllDailyRecords(
+        graphUrls,
+        chain,
+        timestamp
+      );
       const filteredRecords = allDailyRecords
         .map((dayData) => {
           if (dayData.date <= formattedTimestamp) {

--- a/fees/valorem/index.ts
+++ b/fees/valorem/index.ts
@@ -1,5 +1,5 @@
-import { Adapter, BreakdownAdapter } from "../../adapters/types";
-import { ETHEREUM, ARBITRUM } from "../../helpers/chains";
+import { Adapter } from "../../adapters/types";
+import { ARBITRUM } from "../../helpers/chains";
 import { Chain } from "@defillama/sdk/build/general";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import type { ChainEndpoints } from "../../adapters/types";
@@ -10,24 +10,6 @@ import {
 } from "./constants";
 import { IValoremDayData } from "./interfaces";
 import { getAllDailyRecords } from "./helpers";
-
-const graphExchange = (_graphUrls: ChainEndpoints) => {
-  return (_chain: Chain) => {
-    return async (timestamp: number) => {
-      return {
-        timestamp,
-        dailyFees: undefined,
-        dailyUserFees: undefined,
-        dailyRevenue: undefined,
-        dailyProtocolRevenue: undefined,
-        totalFees: undefined,
-        totalUserFees: undefined,
-        totalRevenue: undefined,
-        totalProtocolRevenue: undefined,
-      };
-    };
-  };
-};
 
 const graphOptions = (graphUrls: ChainEndpoints) => {
   return (chain: Chain) => {
@@ -122,62 +104,16 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
   };
 };
 
-// breakdown adapter, provides views for different segments
-const adapter: BreakdownAdapter = {
-  breakdown: {
-    ["Options"]: {
-      [ETHEREUM]: {
-        fetch: graphOptions(endpoints)(ETHEREUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-        meta: {
-          methodology,
-        },
-      },
-      [ARBITRUM]: {
-        fetch: graphOptions(endpoints)(ARBITRUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-        meta: {
-          methodology,
-        },
-      },
-    },
-    ["Exchange"]: {
-      [ETHEREUM]: {
-        fetch: graphExchange(endpoints)(ETHEREUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-        meta: {
-          methodology,
-        },
-      },
-      [ARBITRUM]: {
-        fetch: graphExchange(endpoints)(ARBITRUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-        meta: {
-          methodology,
-        },
+const adapter: Adapter = {
+  adapter: {
+    [ARBITRUM]: {
+      fetch: graphOptions(endpoints)(ARBITRUM),
+      start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+      meta: {
+        methodology,
       },
     },
   },
 };
 
 export default adapter;
-
-// simple adapter, no segmenting OSE/Quay Exchange
-// const adapter: Adapter = {
-//   adapter: {
-//     [ETHEREUM]: {
-//       fetch: graphOptions(endpoints)(ETHEREUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//     [ARBITRUM]: {
-//       fetch: graphOptions(endpoints)(ARBITRUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//   },
-// };

--- a/fees/valorem/index.ts
+++ b/fees/valorem/index.ts
@@ -122,31 +122,11 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
   };
 };
 
-// simple adapter, no segmenting OSE/Quay Exchange
-// const adapter: Adapter = {
-//   adapter: {
-//     /** GOERLI */ [ETHEREUM]: {
-//       fetch: graphOptions(endpoints)(ETHEREUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//     [ARBITRUM]: {
-//       fetch: graphOptions(endpoints)(ARBITRUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//   },
-// };
-
 // breakdown adapter, provides views for different segments
 const adapter: BreakdownAdapter = {
   breakdown: {
     ["Options"]: {
-      /** GOERLI */ [ETHEREUM]: {
+      [ETHEREUM]: {
         fetch: graphOptions(endpoints)(ETHEREUM),
         start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
         meta: {
@@ -162,7 +142,7 @@ const adapter: BreakdownAdapter = {
       },
     },
     ["Exchange"]: {
-      /** GOERLI */ [ETHEREUM]: {
+      [ETHEREUM]: {
         fetch: graphExchange(endpoints)(ETHEREUM),
         start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
         meta: {
@@ -181,3 +161,23 @@ const adapter: BreakdownAdapter = {
 };
 
 export default adapter;
+
+// simple adapter, no segmenting OSE/Quay Exchange
+// const adapter: Adapter = {
+//   adapter: {
+//     [ETHEREUM]: {
+//       fetch: graphOptions(endpoints)(ETHEREUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//     [ARBITRUM]: {
+//       fetch: graphOptions(endpoints)(ARBITRUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//   },
+// };

--- a/fees/valorem/index.ts
+++ b/fees/valorem/index.ts
@@ -1,0 +1,182 @@
+import { Adapter, BreakdownAdapter } from "../../adapters/types";
+import { ETHEREUM, ARBITRUM } from "../../helpers/chains";
+import { Chain } from "@defillama/sdk/build/general";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import type { ChainEndpoints } from "../../adapters/types";
+import {
+  endpoints,
+  OSE_DEPLOY_TIMESTAMP_BY_CHAIN,
+  methodology,
+} from "./constants";
+import { IValoremDayData } from "./interfaces";
+import { getAllDailyRecords } from "./helpers";
+
+const graphExchange = (_graphUrls: ChainEndpoints) => {
+  return (_chain: Chain) => {
+    return async (timestamp: number) => {
+      return {
+        timestamp,
+        dailyFees: undefined,
+        dailyUserFees: undefined,
+        dailyRevenue: undefined,
+        dailyProtocolRevenue: undefined,
+        totalFees: undefined,
+        totalUserFees: undefined,
+        totalRevenue: undefined,
+        totalProtocolRevenue: undefined,
+      };
+    };
+  };
+};
+
+const graphOptions = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const formattedTimestamp = getUniqStartOfTodayTimestamp(
+        new Date(timestamp * 1000)
+      );
+
+      // get all daily records and filter out any that are after the timestamp
+      const allDailyRecords = await getAllDailyRecords(graphUrls, chain);
+      const filteredRecords = allDailyRecords
+        .map((dayData) => {
+          if (dayData.date <= formattedTimestamp) {
+            return dayData;
+          }
+        })
+        .filter((x) => x !== undefined) as IValoremDayData[];
+
+      const getTodaysStats = () => {
+        let todayStats = filteredRecords.find(
+          (dayData) => dayData.date === formattedTimestamp
+        );
+
+        // return with values set to 0 if not found
+        if (!todayStats) {
+          return {
+            dailyFees: undefined,
+            dailyUserFees: undefined,
+            dailyRevenue: undefined,
+            dailyProtocolRevenue: undefined,
+          };
+        }
+
+        return {
+          dailyFees: todayStats.notionalVolFeesAccruedUSD,
+          dailyUserFees: todayStats.notionalVolFeesAccruedUSD,
+          dailyRevenue: todayStats.notionalVolFeesAccruedUSD,
+          dailyProtocolRevenue: todayStats.notionalVolFeesAccruedUSD,
+        };
+      };
+
+      const todaysStats = getTodaysStats();
+
+      // add up totals from each individual preceding day
+      const totalStatsUpToToday = filteredRecords.reduce(
+        (acc, dayData) => {
+          return {
+            totalFees:
+              acc.totalFees + Number(dayData.notionalVolFeesAccruedUSD),
+            totalUserFees:
+              acc.totalUserFees + Number(dayData.notionalVolFeesAccruedUSD),
+            totalRevenue:
+              acc.totalRevenue + Number(dayData.notionalVolFeesAccruedUSD),
+            totalProtocolRevenue:
+              acc.totalProtocolRevenue +
+              Number(dayData.notionalVolFeesAccruedUSD),
+          };
+        },
+        {
+          totalFees: 0,
+          totalUserFees: 0,
+          totalRevenue: 0,
+          totalProtocolRevenue: 0,
+        }
+      );
+
+      return {
+        timestamp,
+        dailyFees: todaysStats.dailyFees,
+        dailyUserFees: todaysStats.dailyUserFees,
+        dailyRevenue: todaysStats.dailyRevenue,
+        dailyProtocolRevenue: todaysStats.dailyProtocolRevenue,
+        totalFees:
+          totalStatsUpToToday.totalFees > 0
+            ? totalStatsUpToToday.totalFees.toString()
+            : undefined,
+        totalUserFees:
+          totalStatsUpToToday.totalUserFees > 0
+            ? totalStatsUpToToday.totalUserFees.toString()
+            : undefined,
+        totalRevenue:
+          totalStatsUpToToday.totalRevenue > 0
+            ? totalStatsUpToToday.totalRevenue.toString()
+            : undefined,
+        totalProtocolRevenue:
+          totalStatsUpToToday.totalProtocolRevenue > 0
+            ? totalStatsUpToToday.totalProtocolRevenue.toString()
+            : undefined,
+      };
+    };
+  };
+};
+
+// simple adapter, no segmenting OSE/Quay Exchange
+// const adapter: Adapter = {
+//   adapter: {
+//     /** GOERLI */ [ETHEREUM]: {
+//       fetch: graphOptions(endpoints)(ETHEREUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//     [ARBITRUM]: {
+//       fetch: graphOptions(endpoints)(ARBITRUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//   },
+// };
+
+// breakdown adapter, provides views for different segments
+const adapter: BreakdownAdapter = {
+  breakdown: {
+    ["Options"]: {
+      /** GOERLI */ [ETHEREUM]: {
+        fetch: graphOptions(endpoints)(ETHEREUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+        meta: {
+          methodology,
+        },
+      },
+      [ARBITRUM]: {
+        fetch: graphOptions(endpoints)(ARBITRUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+        meta: {
+          methodology,
+        },
+      },
+    },
+    ["Exchange"]: {
+      /** GOERLI */ [ETHEREUM]: {
+        fetch: graphExchange(endpoints)(ETHEREUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+        meta: {
+          methodology,
+        },
+      },
+      [ARBITRUM]: {
+        fetch: graphExchange(endpoints)(ARBITRUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+        meta: {
+          methodology,
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/fees/valorem/interfaces.ts
+++ b/fees/valorem/interfaces.ts
@@ -13,3 +13,22 @@ export interface IValoremDayData {
 export interface IValoremDailyRecordsResponse {
   dayDatas: IValoremDayData[];
 }
+
+export interface IValoremTokenDayData {
+  date: number;
+  token: {
+    symbol: string;
+  };
+  notionalVolWritten: string;
+  notionalVolTransferred: string;
+  notionalVolSettled: string;
+  notionalVolRedeemed: string;
+  notionalVolExercised: string;
+  notionalVolCoreSum: string;
+  volFeesAccrued: string;
+  volFeesSwept: string;
+}
+
+export interface IValoremDailyTokenRecordsResponse {
+  tokenDayDatas: IValoremTokenDayData[];
+}

--- a/fees/valorem/interfaces.ts
+++ b/fees/valorem/interfaces.ts
@@ -1,0 +1,15 @@
+export interface IValoremDayData {
+  date: number;
+  notionalVolWrittenUSD: string;
+  notionalVolExercisedUSD: string;
+  notionalVolRedeemedUSD: string;
+  notionalVolTransferredUSD: string;
+  notionalVolSettledUSD: string;
+  notionalVolSumUSD: string;
+  notionalVolFeesAccruedUSD: string;
+  notionalVolFeesSweptUSD: string;
+}
+
+export interface IValoremDailyRecordsResponse {
+  dayDatas: IValoremDayData[];
+}

--- a/fees/valorem/interfaces.ts
+++ b/fees/valorem/interfaces.ts
@@ -5,9 +5,9 @@ export interface IValoremDayData {
   notionalVolRedeemedUSD: string;
   notionalVolTransferredUSD: string;
   notionalVolSettledUSD: string;
-  notionalVolSumUSD: string;
-  notionalVolFeesAccruedUSD: string;
-  notionalVolFeesSweptUSD: string;
+  notionalVolCoreSumUSD: string;
+  volFeesAccruedUSD: string;
+  volFeesSweptUSD: string;
 }
 
 export interface IValoremDailyRecordsResponse {

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -101,31 +101,11 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
   };
 };
 
-// simple adapter, no segmenting OSE/Quay Exchange
-// const adapter: Adapter = {
-//   adapter: {
-//     /** GOERLI */ [ETHEREUM]: {
-//       fetch: graphOptions(endpoints)(ETHEREUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//     [ARBITRUM]: {
-//       fetch: graphOptions(endpoints)(ARBITRUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//   },
-// };
-
 // breakdown adapter, provides views for different segments
 const adapter: BreakdownAdapter = {
   breakdown: {
     ["Options"]: {
-      /** GOERLI */ [ETHEREUM]: {
+      [ETHEREUM]: {
         fetch: graphOptions(endpoints)(ETHEREUM),
         start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
         meta: {
@@ -141,7 +121,7 @@ const adapter: BreakdownAdapter = {
       },
     },
     ["Exchange"]: {
-      /** GOERLI */ [ETHEREUM]: {
+      [ETHEREUM]: {
         fetch: graphExchange(endpoints)(ETHEREUM),
         start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
         meta: {
@@ -160,3 +140,23 @@ const adapter: BreakdownAdapter = {
 };
 
 export default adapter;
+
+// simple adapter, no segmenting OSE/Quay Exchange
+// const adapter: Adapter = {
+//   adapter: {
+//     [ETHEREUM]: {
+//       fetch: graphOptions(endpoints)(ETHEREUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//     [ARBITRUM]: {
+//       fetch: graphOptions(endpoints)(ARBITRUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//   },
+// };

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -56,7 +56,7 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
         }
 
         return {
-          dailyNotionalVolume: todayStats.notionalVolSumUSD,
+          dailyNotionalVolume: todayStats.notionalVolCoreSumUSD,
           dailyPremiumVolume: undefined,
         };
       };
@@ -68,10 +68,10 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
         (acc, dayData) => {
           return {
             totalNotionalVolume:
-              acc.totalNotionalVolume + Number(dayData.notionalVolSumUSD),
+              acc.totalNotionalVolume + Number(dayData.notionalVolCoreSumUSD),
             totalPremiumVolume:
               acc.totalPremiumVolume +
-              Number(/** dayData.premiumVolSumUSD */ "0"),
+              Number(/** dayData.premiumVolCoreSumUSD */ "0"),
           };
         },
         {

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -1,0 +1,158 @@
+import { Adapter, BreakdownAdapter } from "../../adapters/types";
+import { ETHEREUM, ARBITRUM } from "../../helpers/chains";
+import { Chain } from "@defillama/sdk/build/general";
+import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
+import type { ChainEndpoints } from "../../adapters/types";
+import {
+  endpoints,
+  OSE_DEPLOY_TIMESTAMP_BY_CHAIN,
+  methodology,
+} from "../../fees/valorem/constants";
+import { IValoremDayData } from "../../fees/valorem/interfaces";
+import { getAllDailyRecords } from "../../fees/valorem/helpers";
+
+const graphExchange = (_graphUrls: ChainEndpoints) => {
+  return (_chain: Chain) => {
+    return async (timestamp: number) => {
+      return {
+        timestamp,
+        dailyNotionalVolume: undefined,
+        dailyPremiumVolume: undefined,
+        totalNotionalVolume: undefined,
+        totalPremiumVolume: undefined,
+      };
+    };
+  };
+};
+
+const graphOptions = (graphUrls: ChainEndpoints) => {
+  return (chain: Chain) => {
+    return async (timestamp: number) => {
+      const formattedTimestamp = getUniqStartOfTodayTimestamp(
+        new Date(timestamp * 1000)
+      );
+
+      // get all daily records and filter out any that are after the timestamp
+      const allDailyRecords = await getAllDailyRecords(graphUrls, chain);
+      const filteredRecords = allDailyRecords
+        .map((dayData) => {
+          if (dayData.date <= formattedTimestamp) {
+            return dayData;
+          }
+        })
+        .filter((x) => x !== undefined) as IValoremDayData[];
+
+      const getTodaysStats = () => {
+        let todayStats = filteredRecords.find(
+          (dayData) => dayData.date === formattedTimestamp
+        );
+
+        // return with values set to 0 if not found
+        if (!todayStats) {
+          return {
+            dailyNotionalVolume: undefined,
+            dailyPremiumVolume: undefined,
+          };
+        }
+
+        return {
+          dailyNotionalVolume: todayStats.notionalVolSumUSD,
+          dailyPremiumVolume: undefined,
+        };
+      };
+
+      const todaysStats = getTodaysStats();
+
+      // add up totals from each individual preceding day
+      const totalStatsUpToToday = filteredRecords.reduce(
+        (acc, dayData) => {
+          return {
+            totalNotionalVolume:
+              acc.totalNotionalVolume + Number(dayData.notionalVolSumUSD),
+            totalPremiumVolume:
+              acc.totalPremiumVolume +
+              Number(/** dayData.premiumVolSumUSD */ "0"),
+          };
+        },
+        {
+          totalNotionalVolume: 0,
+          totalPremiumVolume: 0,
+        }
+      );
+
+      return {
+        timestamp,
+        dailyNotionalVolume: todaysStats.dailyNotionalVolume,
+        dailyPremiumVolume: todaysStats.dailyPremiumVolume,
+        totalNotionalVolume:
+          totalStatsUpToToday.totalNotionalVolume > 0
+            ? totalStatsUpToToday.totalNotionalVolume.toString()
+            : undefined,
+        totalPremiumVolume:
+          totalStatsUpToToday.totalPremiumVolume > 0
+            ? totalStatsUpToToday.totalPremiumVolume.toString()
+            : undefined,
+      };
+    };
+  };
+};
+
+// simple adapter, no segmenting OSE/Quay Exchange
+// const adapter: Adapter = {
+//   adapter: {
+//     /** GOERLI */ [ETHEREUM]: {
+//       fetch: graphOptions(endpoints)(ETHEREUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//     [ARBITRUM]: {
+//       fetch: graphOptions(endpoints)(ARBITRUM),
+//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+//       meta: {
+//         methodology,
+//       },
+//     },
+//   },
+// };
+
+// breakdown adapter, provides views for different segments
+const adapter: BreakdownAdapter = {
+  breakdown: {
+    ["Options"]: {
+      /** GOERLI */ [ETHEREUM]: {
+        fetch: graphOptions(endpoints)(ETHEREUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+        meta: {
+          methodology,
+        },
+      },
+      [ARBITRUM]: {
+        fetch: graphOptions(endpoints)(ARBITRUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+        meta: {
+          methodology,
+        },
+      },
+    },
+    ["Exchange"]: {
+      /** GOERLI */ [ETHEREUM]: {
+        fetch: graphExchange(endpoints)(ETHEREUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
+        meta: {
+          methodology,
+        },
+      },
+      [ARBITRUM]: {
+        fetch: graphExchange(endpoints)(ARBITRUM),
+        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+        meta: {
+          methodology,
+        },
+      },
+    },
+  },
+};
+
+export default adapter;

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -33,7 +33,11 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
       );
 
       // get all daily records and filter out any that are after the timestamp
-      const allDailyRecords = await getAllDailyRecords(graphUrls, chain);
+      const allDailyRecords = await getAllDailyRecords(
+        graphUrls,
+        chain,
+        timestamp
+      );
       const filteredRecords = allDailyRecords
         .map((dayData) => {
           if (dayData.date <= formattedTimestamp) {

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -1,5 +1,5 @@
-import { Adapter, BreakdownAdapter } from "../../adapters/types";
-import { ETHEREUM, ARBITRUM } from "../../helpers/chains";
+import { Adapter } from "../../adapters/types";
+import { ARBITRUM } from "../../helpers/chains";
 import { Chain } from "@defillama/sdk/build/general";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
 import type { ChainEndpoints } from "../../adapters/types";

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -2,28 +2,79 @@ import { Adapter } from "../../adapters/types";
 import { ARBITRUM } from "../../helpers/chains";
 import { Chain } from "@defillama/sdk/build/general";
 import { getUniqStartOfTodayTimestamp } from "../../helpers/getUniSubgraphVolume";
-import type { ChainEndpoints } from "../../adapters/types";
+import type { ChainEndpoints, FetchResultOptions } from "../../adapters/types";
 import {
   endpoints,
   OSE_DEPLOY_TIMESTAMP_BY_CHAIN,
   methodology,
 } from "../../fees/valorem/constants";
-import { IValoremDayData } from "../../fees/valorem/interfaces";
-import { getAllDailyRecords } from "../../fees/valorem/helpers";
+import {
+  IValoremDayData,
+  IValoremTokenDayData,
+} from "../../fees/valorem/interfaces";
+import {
+  DailyTokenRecords,
+  getAllDailyRecords,
+  getAllDailyTokenRecords,
+} from "../../fees/valorem/helpers";
 
 const graphOptions = (graphUrls: ChainEndpoints) => {
   return (chain: Chain) => {
-    return async (timestamp: number) => {
+    return async (timestamp: number): Promise<any /* FetchResultOptions */> => {
       const formattedTimestamp = getUniqStartOfTodayTimestamp(
         new Date(timestamp * 1000)
       );
 
+      /** Daily Token Metrics */
+
+      const allDailyTokenRecords = await getAllDailyTokenRecords(
+        graphUrls,
+        chain,
+        timestamp
+      );
+
+      let filteredTokenRecords: DailyTokenRecords = {};
+
+      Object.keys(allDailyTokenRecords).forEach((tokenDayDataKey) => {
+        const filteredTokenDayDatas = allDailyTokenRecords[tokenDayDataKey]
+          .map((tokenDayData) => {
+            if (tokenDayData.date <= formattedTimestamp) {
+              return tokenDayData;
+            }
+          })
+          .filter((x) => x !== undefined);
+        filteredTokenRecords[tokenDayDataKey] =
+          filteredTokenDayDatas as IValoremTokenDayData[];
+      });
+
+      const getTodaysStats = () => {
+        let todayStats = {
+          dailyNotionalVolume: {} as Record<string, string | undefined>,
+          dailyPremiumVolume: undefined,
+        };
+
+        Object.keys(filteredTokenRecords).forEach((key) => {
+          const todaysDataForToken = filteredTokenRecords[key].find(
+            (dayData) => dayData.date === formattedTimestamp
+          );
+          todayStats.dailyNotionalVolume[key] =
+            todaysDataForToken?.notionalVolCoreSum ?? undefined;
+        });
+
+        return todayStats;
+      };
+
+      const todaysStats = getTodaysStats();
+
+      /** Backfilled USD Metrics */
+      // add up totals from each individual preceding day
       // get all daily records and filter out any that are after the timestamp
       const allDailyRecords = await getAllDailyRecords(
         graphUrls,
         chain,
         timestamp
       );
+
       const filteredRecords = allDailyRecords
         .map((dayData) => {
           if (dayData.date <= formattedTimestamp) {
@@ -31,42 +82,20 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
           }
         })
         .filter((x) => x !== undefined) as IValoremDayData[];
-
-      const getTodaysStats = () => {
-        let todayStats = filteredRecords.find(
-          (dayData) => dayData.date === formattedTimestamp
-        );
-
-        // return with values set to 0 if not found
-        if (!todayStats) {
-          return {
-            dailyNotionalVolume: undefined,
-            dailyPremiumVolume: undefined,
-          };
-        }
-
-        return {
-          dailyNotionalVolume: todayStats.notionalVolCoreSumUSD,
-          dailyPremiumVolume: undefined,
-        };
-      };
-
-      const todaysStats = getTodaysStats();
-
       // add up totals from each individual preceding day
       const totalStatsUpToToday = filteredRecords.reduce(
         (acc, dayData) => {
           return {
-            totalNotionalVolume:
-              acc.totalNotionalVolume + Number(dayData.notionalVolCoreSumUSD),
-            totalPremiumVolume:
-              acc.totalPremiumVolume +
-              Number(/** dayData.premiumVolCoreSumUSD */ "0"),
+            totalNotionalVolume: (
+              Number(acc.totalNotionalVolume) +
+              Number(dayData.notionalVolCoreSumUSD)
+            ).toString(),
+            totalPremiumVolume: undefined,
           };
         },
         {
-          totalNotionalVolume: 0,
-          totalPremiumVolume: 0,
+          totalNotionalVolume: "0",
+          totalPremiumVolume: undefined,
         }
       );
 
@@ -74,14 +103,8 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
         timestamp,
         dailyNotionalVolume: todaysStats.dailyNotionalVolume,
         dailyPremiumVolume: todaysStats.dailyPremiumVolume,
-        totalNotionalVolume:
-          totalStatsUpToToday.totalNotionalVolume > 0
-            ? totalStatsUpToToday.totalNotionalVolume.toString()
-            : undefined,
-        totalPremiumVolume:
-          totalStatsUpToToday.totalPremiumVolume > 0
-            ? totalStatsUpToToday.totalPremiumVolume.toString()
-            : undefined,
+        totalNotionalVolume: totalStatsUpToToday.totalNotionalVolume,
+        totalPremiumVolume: totalStatsUpToToday.totalPremiumVolume,
       };
     };
   };

--- a/options/valorem/index.ts
+++ b/options/valorem/index.ts
@@ -11,20 +11,6 @@ import {
 import { IValoremDayData } from "../../fees/valorem/interfaces";
 import { getAllDailyRecords } from "../../fees/valorem/helpers";
 
-const graphExchange = (_graphUrls: ChainEndpoints) => {
-  return (_chain: Chain) => {
-    return async (timestamp: number) => {
-      return {
-        timestamp,
-        dailyNotionalVolume: undefined,
-        dailyPremiumVolume: undefined,
-        totalNotionalVolume: undefined,
-        totalPremiumVolume: undefined,
-      };
-    };
-  };
-};
-
 const graphOptions = (graphUrls: ChainEndpoints) => {
   return (chain: Chain) => {
     return async (timestamp: number) => {
@@ -101,62 +87,16 @@ const graphOptions = (graphUrls: ChainEndpoints) => {
   };
 };
 
-// breakdown adapter, provides views for different segments
-const adapter: BreakdownAdapter = {
-  breakdown: {
-    ["Options"]: {
-      [ETHEREUM]: {
-        fetch: graphOptions(endpoints)(ETHEREUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-        meta: {
-          methodology,
-        },
-      },
-      [ARBITRUM]: {
-        fetch: graphOptions(endpoints)(ARBITRUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-        meta: {
-          methodology,
-        },
-      },
-    },
-    ["Exchange"]: {
-      [ETHEREUM]: {
-        fetch: graphExchange(endpoints)(ETHEREUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-        meta: {
-          methodology,
-        },
-      },
-      [ARBITRUM]: {
-        fetch: graphExchange(endpoints)(ARBITRUM),
-        start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-        meta: {
-          methodology,
-        },
+const adapter: Adapter = {
+  adapter: {
+    [ARBITRUM]: {
+      fetch: graphOptions(endpoints)(ARBITRUM),
+      start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
+      meta: {
+        methodology,
       },
     },
   },
 };
 
 export default adapter;
-
-// simple adapter, no segmenting OSE/Quay Exchange
-// const adapter: Adapter = {
-//   adapter: {
-//     [ETHEREUM]: {
-//       fetch: graphOptions(endpoints)(ETHEREUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ETHEREUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//     [ARBITRUM]: {
-//       fetch: graphOptions(endpoints)(ARBITRUM),
-//       start: async () => OSE_DEPLOY_TIMESTAMP_BY_CHAIN[ARBITRUM],
-//       meta: {
-//         methodology,
-//       },
-//     },
-//   },
-// };


### PR DESCRIPTION
### Test Outputs

<summary>

`yarn test fees valorem`

<details>

```
🦙 Running VALOREM adapter 🦙
_______________________________________
Fees for 6/9/2023
_______________________________________
ARBITRUM 👇
Backfill start time: 1/9/2023
Timestamp: 1694044798
Daily fees: undefined
Daily user fees: undefined
Daily revenue: undefined
Daily protocol revenue: undefined
Total fees: undefined
Total user fees: undefined
Total revenue: undefined
Total protocol revenue: undefined
```

</details>
</summary>

<summary>

`yarn test options valorem`

<details>

```
_______________________________________
Options for 6/9/2023
_______________________________________

ARBITRUM 👇
Backfill start time: 1/9/2023
Timestamp: 1694044798
Daily notional volume: undefined
Daily premium volume: undefined
Total notional volume: 13037.28838526646
└─ Methodology: Notional Volume is calculated with the market value of the Underlying + Exercise assets of a position at the time of Write/Exercise/Redeem/Transfer.
Total premium volume: undefined
```

</details>
</summary>

---

## closes #1 #2

from #2:
- **What:** A DeFiLlama view of Notional Volumes:
  :heavy_check_mark: Total Notional Volume (Write + Exercise + Redeem + Transfer) 
  :x: Settled Notional Volume (Write + Exercise, protocol fee is assessed)
  :x: Write Notional Volume (underlying)
  :x: Exercise Notional Volume (exercise)
  :x: Redeem Notional Volume (underlying and/or exercise)
  :x: Transfer Notional Volume (underlying and/or exercise)
- **Why:** To support KPI reporting and OKR process
### DefiLlama only supports total notional volume. The other breakdowns are on subgraph.

---

from #1:
- **What:** A DeFiLlama view of Fees Accrued
  :x: Token name
  :x: Token symbol
  :heavy_check_mark: Token address
  :heavy_check_mark: Fees accrued lifetime
  :x: Fee balance current
- **Why:** To support KPI reporting and OKR process
### DefiLlama only tracks lifetime fees accrued for a set of addresses. Name, Symbol, and current feeBalance are on subgraph.

---

from [#2 in DefiLlama-Adapters](https://github.com/valorem-labs-inc/DefiLlama-Adapters/issues/2):
[Dimensions Fetch Adapter](https://docs.llama.fi/list-your-project/other-dashboards/dimensions)
The dimension-adapters can source data from Subgraphs (fetch adapter) though; with PRs as recent as this week  being merged using Subgraphs.

- `options/valorem`
    - [x] dailyNotionalVolume: on subgraph
    - [x] totalNotionalVolume: on subgraph
    - :x: :warning: dailyPremiumVolume: **depends on future quay exchange**
    - :x: :warning: totalPremiumVolume: **depends on future quay exchange**
- `fees/valorem`
    - [x] dailyFees: All fees and value collected from all sources, this also includes liquid staking rewards, generated yields and possible mint and burn fees paid by LP (but not transaction or gas fees).
    - [x] dailyUserFees: Fees paid by protocol users excluding gas fees. This includes swap fees to open/close positions, borrow fees and all fees user has to pay.
    - [x] dailyRevenue: Revenue of the protocol governance, this includes treasury and gov token holders (dailyHoldersRevenue + dailyProtocolRevenue)
    - [x] dailyProtocolRevenue: ~Treasury revenue.~ **Revenue from fees.**
    - [x] totalXXX: Cumulative values of the above.
    - :x: :warning: dailyHoldersRevenue: **N/A (no governance tokens to hold)** ~Value going to gov token holders, this includes burned coins.~ 
    - :x: :warning: dailySupplySideRevenue: **N/A (no pools to provide liquidity to)** ~Value earned by liquidity providers.~
- `dexs/valorem` (for future Quay exchange)
    - :x: :warning: dailyVolume: **depends on future quay exchange**
    - :x: :warning: totalVolume: **depends on future quay exchange**
- [x] All of these need to be chain-aware as well
